### PR TITLE
Support for long queue IDs

### DIFF
--- a/pymailq/store.py
+++ b/pymailq/store.py
@@ -337,9 +337,13 @@ class PostqueueStore(object):
 
             Python compiled regular expression object (:class:`re.RegexObject`)
             provided by :func:`re.compile` method to match postfix IDs.
-            Recognized IDs are hexadecimals, may be 10 to 12 chars length and
-            followed with ``*`` or ``!``.
-            Default used regular expression is: ``r"^[A-F0-9]{10,12}[*!]?$"``.
+            Recognized IDs are either:
+                - hexadecimals, 8 to 12 chars length (regular queue IDs)
+                - encoded in a 52-character alphabet, 11 to 16 chars length
+                  (long queue IDs)
+            They can be followed with ``*`` or ``!``.
+            Default used regular expression is:
+                ``r"^([A-F0-9]{8,12}|[B-Zb-z0-9]{11,16})[*!]?$"``.
 
         .. attribute:: mail_addr_re
 
@@ -368,7 +372,7 @@ class PostqueueStore(object):
     postqueue_cmd = None
     spool_path = None
     postqueue_mailstatus = ['active', 'deferred', 'hold']
-    mail_id_re = re.compile(r"^[A-F0-9]{8,12}[*!]?$")
+    mail_id_re = re.compile(r"^([A-F0-9]{8,12}|[B-Zb-z0-9]{11,16})[*!]?$")
     mail_addr_re = re.compile(r"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+$")
     MailClass = Mail
 


### PR DESCRIPTION
Postfix 2.9 and later provide a way to generate long, non-repeating, queue IDs.
See http://www.postfix.org/postconf.5.html#enable_long_queue_ids

This fixes the regex used to match queue ids to support this new syntax